### PR TITLE
Fix sample_test_run address resolving command

### DIFF
--- a/samples/socket-api/sample_test_run.py
+++ b/samples/socket-api/sample_test_run.py
@@ -121,7 +121,6 @@ def main():
         print("\n================================")
         print("Test address resolving")
         cmd = "./iwasm --allow-resolve=*.com addr_resolve.wasm github.com"
-        cmd = "./multicast_server FF02:113D:6FDD:2C17:A643:FFE2:1BD1:3CD2"
         run_cmd(cmd, args.working_directory)
 
         # wait for a second


### PR DESCRIPTION
## Summary
- remove incorrect multicast command in socket API sample
- always run the intended address resolution test command

## Testing
- `python3 -m py_compile samples/socket-api/sample_test_run.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'wamr')*

------
https://chatgpt.com/codex/tasks/task_e_683fddbbe6d88324b3572820947e2194