### PR TITLE
Fix typo in wasm value comparison

### DIFF
--- a/language-bindings/python/src/wamr/wasmcapi/ffi.py
+++ b/language-bindings/python/src/wamr/wasmcapi/ffi.py
@@ -405,7 +405,7 @@ def __compare_wasm_val_t(self, other):
     elif WASM_F32 == self.kind:
         return self.of.f32 == other.of.f32
     elif WASM_F64 == self.kind:
-        return self.of.f64 == other.of.f63
+        return self.of.f64 == other.of.f64
     elif WASM_EXTERNREF == self.kind:
         raise RuntimeError("FIXME")
     else:


### PR DESCRIPTION
## Summary
- fix typo in wasm value comparison logic

## Testing
- `pytest -q wasm-c-api/tests/test_basic.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683fdd801e088324a6854fe24f5a15f2