### PR TITLE
Fix vec util variable naming

### DIFF
--- a/language-bindings/python/src/wamr/wasmcapi/ffi.py
+++ b/language-bindings/python/src/wamr/wasmcapi/ffi.py
@@ -112,12 +112,12 @@ def wasm_vec_to_list(vec):
         wasm_frame_vec_t,
         wasm_extern_vec_t,
     ]
-    known_vec_pointer_type = [POINTER(type) for type in known_vec_type]
+    known_vec_pointer_type = [POINTER(vec_type) for vec_type in known_vec_type]
 
-    if any([isinstance(vec, type) for type in known_vec_pointer_type]):
+    if any([isinstance(vec, pointer_type) for pointer_type in known_vec_pointer_type]):
         vec = dereference(vec)
         return [vec.data[i] for i in range(vec.num_elems)]
-    elif any([isinstance(vec, type) for type in known_vec_type]):
+    elif any([isinstance(vec, vec_type) for vec_type in known_vec_type]):
         return [vec.data[i] for i in range(vec.num_elems)]
     else:
         raise RuntimeError("not a known vector type")


### PR DESCRIPTION
## Summary
- fix vector pointer type generation in Python FFI to avoid shadowing Python builtin

## Testing
- `pytest -k wasm_vec_to_list` *(fails: ModuleNotFoundError: No module named 'wamr')*

------
https://chatgpt.com/codex/tasks/task_e_683fddaa83788324a9888cac1df7b002