### PR TITLE
Fix typo in ref_types

### DIFF
--- a/doc/ref_types.md
+++ b/doc/ref_types.md
@@ -4,6 +4,6 @@ WebAssembly [reference-types](https://github.com/WebAssembly/reference-types) pr
 
 WAMR has implemented the reference-types proposal. WAMR allows a native method to pass a host object to a WASM application as an `externref` parameter or receives a host object from a WASM application as an `externref` result. Internally, WAMR won't try to parse or dereference `externref`. It is an opaque type.
 
-The restriction of using `externref` in a native method is the host object has to be the value of a `unintptr_t` variable. In other words, it takes **8 bytes** on 64-bit machine and **4 bytes** on 32-bit machines. Please keep that in mind especially when calling `wasm_runtime_call_wasm`.
+The restriction of using `externref` in a native method is the host object has to be the value of a `uintptr_t` variable. In other words, it takes **8 bytes** on 64-bit machine and **4 bytes** on 32-bit machines. Please keep that in mind especially when calling `wasm_runtime_call_wasm`.
 
 Please ref to the [sample](../samples/ref-types) for more details.


### PR DESCRIPTION
## Summary
- correct `uintptr_t` type name in `ref_types.md`

## Testing
- `python3 -m unittest ci/coding_guidelines_check.py`

------
https://chatgpt.com/codex/tasks/task_e_6841654f59548324907e910c29f8522b