### PR TITLE
Fix typos and openat mode handling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -497,7 +497,7 @@
 - wasm loader: Fix handling if block without op else (#3404)
 - ref-types: Correct default value for function local variables (#3397)
 - aot compiler: Fix the length type passed to aot_memmove/aot_memset (#3378)
-- Fix loader and mini-loader select potiential error (#3374)
+- Fix loader and mini-loader select potential error (#3374)
 - Fix aot debugger compilation error on windows (#3370)
 - A few native stack detection fixes for macOS/arm64 (#3368)
 - Fix ESP32-S3 compiling error (#3359)

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -3712,7 +3712,7 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
              * we shall make a copy of code body [p_code, p_code + code_size]
              * when we are worrying about inappropriate releasing behaviour.
              * all code bodies are actually in a buffer which user allocates in
-             * his embedding environment and we don't have power on them.
+             * their embedding environment and we don't have power over them.
              * it will be like:
              * code_body_cp = malloc(code_size);
              * memcpy(code_body_cp, p_code, code_size);

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1226,7 +1226,7 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
              * we shall make a copy of code body [p_code, p_code + code_size]
              * when we are worrying about inappropriate releasing behaviour.
              * all code bodies are actually in a buffer which user allocates in
-             * his embedding environment and we don't have power on them.
+             * their embedding environment and we don't have power over them.
              * it will be like:
              * code_body_cp = malloc(code_size);
              * memcpy(code_body_cp, p_code, code_size);

--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -201,10 +201,20 @@ openat(int fd, const char *pathname, int flags, ...)
     int ret;
     char dir_path[DIR_PATH_LEN];
     char *full_path;
+    mode_t mode = 0;
+    bool has_mode = false;
+
+    if (flags & O_CREAT) {
+        va_list ap;
+        va_start(ap, flags);
+        mode = (mode_t)va_arg(ap, int);
+        va_end(ap);
+        has_mode = true;
+    }
 
     ret = fcntl(fd, F_GETPATH, dir_path);
     if (ret != 0) {
-        errno = -EINVAL;
+        errno = EINVAL;
         return -1;
     }
 
@@ -214,7 +224,7 @@ openat(int fd, const char *pathname, int flags, ...)
         return -1;
     }
 
-    new_fd = open(full_path, flags);
+    new_fd = has_mode ? open(full_path, flags, mode) : open(full_path, flags);
     free(full_path);
 
     return new_fd;

--- a/language-bindings/python/wamr-api/README.md
+++ b/language-bindings/python/wamr-api/README.md
@@ -6,7 +6,7 @@
 
 ### Pre-requisites
 #### Install requirements
-Before proceeding it is necessary to make sure your Python environment is correctly configured. To do ths open a terminal session in this directory and perfom the following:
+Before proceeding it is necessary to make sure your Python environment is correctly configured. To do this open a terminal session in this directory and perform the following:
 
 
 ```shell


### PR DESCRIPTION
## Summary
- correct wording in comments and docs
- handle optional mode argument in esp-idf openat implementation
- fix openat error assignment

## Testing
- `cmake ..` *(fails: unable to access 'https://github.com/simd-everywhere/simde/')*

------
https://chatgpt.com/codex/tasks/task_e_684faccaa8ac8324acc0e7a4509923ab