### PR TITLE
Fix vector growth check and typos in core

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -3999,7 +3999,7 @@ aot_get_func_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
 
     if (!(func =
               LLVMBuildBitCast(comp_ctx->builder, func, func_type, "func"))) {
-        aot_set_last_error("cast function fialed.");
+        aot_set_last_error("cast function failed.");
         goto fail;
     }
 
@@ -4068,7 +4068,7 @@ aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
 
     if (!(const_addr = LLVMBuildBitCast(comp_ctx->builder, const_addr,
                                         const_ptr_type, "const_addr"))) {
-        aot_set_last_error("cast const fialed.");
+        aot_set_last_error("cast const failed.");
         return NULL;
     }
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2668,7 +2668,7 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
                         }
                         STORE_PTR((void **)global_data, func_obj);
                         global_data += sizeof(void *);
-                        /* Also update the inital_value since other globals may
+                        /* Also update the initial_value since other globals may
                          * refer to this */
                         global->initial_value.gc_obj = (wasm_obj_t)func_obj;
                         break;

--- a/core/shared/utils/bh_vector.c
+++ b/core/shared/utils/bh_vector.c
@@ -35,8 +35,8 @@ extend_vector(Vector *vector, size_t length)
     if (length <= vector->max_elems)
         return true;
 
-    if (length < vector->size_elem * 3 / 2)
-        length = vector->size_elem * 3 / 2;
+    if (length < vector->max_elems * 3 / 2)
+        length = vector->max_elems * 3 / 2;
 
     if (!(data = alloc_vector_data(length, vector->size_elem))) {
         return false;
@@ -194,12 +194,12 @@ bh_vector_append(Vector *vector, const void *elem_buf)
         goto just_return;
     }
 
-    /* make sure one more slot is used by the thread who allocas it */
+    /* make sure one more slot is used by the thread who allocates it */
     if (vector->lock)
         os_mutex_lock(vector->lock);
 
     if (!extend_vector(vector, vector->num_elems + 1)) {
-        LOG_ERROR("Append ector elem failed: extend vector failed.\n");
+        LOG_ERROR("Append vector elem failed: extend vector failed.\n");
         goto unlock_return;
     }
 


### PR DESCRIPTION
## Summary
- correct a minor typo in wasm_runtime.c comment
- fix extend_vector to use max_elems when determining growth
- clean up typos in bh_vector (log message and comment)

## Testing
- `cmake ..` *(fails: failed to clone simde)*

------
https://chatgpt.com/codex/tasks/task_e_685b97455cb083249e6e2fa9f0651153