### PR TITLE
Fix typos in socket sample

### DIFF
--- a/samples/socket-api/README.md
+++ b/samples/socket-api/README.md
@@ -79,7 +79,7 @@ Client is running...
 Start receiving.
 Start sending.
 Send 106 bytes successfully!
-Receive 106 bytes successlly!
+Receive 106 bytes successfully!
 Data:
   The stars shine down
   It brings us light

--- a/samples/socket-api/wasm-src/send_recv.c
+++ b/samples/socket-api/wasm-src/send_recv.c
@@ -25,6 +25,7 @@ static bool server_is_ready = false;
 void *
 run_as_server(void *arg)
 {
+    (void)arg;
     int sock = -1, on = 1;
     struct sockaddr_in addr = { 0 };
     int addrlen = 0;
@@ -109,7 +110,7 @@ run_as_server(void *arg)
 fail2:
     close(new_sock);
 fail1:
-    shutdown(sock, SHUT_RD);
+    shutdown(sock, SHUT_RDWR);
     close(sock);
     return NULL;
 }
@@ -117,6 +118,7 @@ fail1:
 void *
 run_as_client(void *arg)
 {
+    (void)arg;
     int sock = -1;
     struct sockaddr_in addr = { 0 };
     /* buf of server is 106 bytes */
@@ -159,7 +161,7 @@ run_as_client(void *arg)
         goto fail;
     }
 
-    printf("Receive %ld bytes successlly!\n", recv_len);
+    printf("Receive %ld bytes successfully!\n", recv_len);
     assert(recv_len == 106);
 
     printf("Data:\n");
@@ -170,7 +172,7 @@ run_as_client(void *arg)
     }
 
 fail:
-    shutdown(sock, SHUT_RD);
+    shutdown(sock, SHUT_RDWR);
     close(sock);
     return NULL;
 }
@@ -178,6 +180,8 @@ fail:
 int
 main(int argc, char *argv[])
 {
+    (void)argc;
+    (void)argv;
     pthread_t cs[2] = { 0 };
     uint8_t i = 0;
     int ret = EXIT_SUCCESS;

--- a/samples/wasm-c-api-imports/wasm/send_recv.c
+++ b/samples/wasm-c-api-imports/wasm/send_recv.c
@@ -50,6 +50,7 @@ local_printf(const char *formatter, ...)
 void *
 run_as_server(void *arg)
 {
+    (void)arg;
     int sock = -1, on = 1;
     struct sockaddr_in addr = { 0 };
     int addrlen = 0;
@@ -134,7 +135,7 @@ run_as_server(void *arg)
 fail2:
     close(new_sock);
 fail1:
-    shutdown(sock, SHUT_RD);
+    shutdown(sock, SHUT_RDWR);
     close(sock);
     return NULL;
 }
@@ -142,6 +143,7 @@ fail1:
 void *
 run_as_client(void *arg)
 {
+    (void)arg;
     int sock = -1;
     struct sockaddr_in addr = { 0 };
     /* buf of server is 106 bytes */
@@ -184,7 +186,7 @@ run_as_client(void *arg)
         goto fail;
     }
 
-    local_printf("Receive %ld bytes successlly!\n", recv_len);
+    local_printf("Receive %ld bytes successfully!\n", recv_len);
     assert(recv_len == 106);
 
     local_printf("Data:\n");
@@ -195,7 +197,7 @@ run_as_client(void *arg)
     }
 
 fail:
-    shutdown(sock, SHUT_RD);
+    shutdown(sock, SHUT_RDWR);
     close(sock);
     return NULL;
 }
@@ -203,6 +205,8 @@ fail:
 int
 main(int argc, char *argv[])
 {
+    (void)argc;
+    (void)argv;
     pthread_t cs[2] = { 0 };
     uint8_t i = 0;
     int ret = EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- fix typos in socket sample README and source
- silence unused parameter warnings in the send/recv samples
- use `SHUT_RDWR` when closing sockets

## Testing
- `gcc -Wall -Wextra -Werror -c samples/socket-api/wasm-src/send_recv.c -o /tmp/send_recv.o && echo "socket compiled" && gcc -Wall -Wextra -Werror -c samples/wasm-c-api-imports/wasm/send_recv.c -o /tmp/send_recv_wasi.o && echo "wasi compiled"`


------
https://chatgpt.com/codex/tasks/task_e_6861fbeac7a4832480fb9eb52e7c2beb