### PR TITLE
Switch third-party dependencies to Intel forks

### DIFF
--- a/core/iwasm/libraries/libc-uvwasi/libc_uvwasi.cmake
+++ b/core/iwasm/libraries/libc-uvwasi/libc_uvwasi.cmake
@@ -26,7 +26,7 @@ if (LIBUV_FOUND)
 else()
     FetchContent_Declare(
         libuv
-        GIT_REPOSITORY https://github.com/libuv/libuv.git
+        GIT_REPOSITORY https://github.com/intel-innersource/thirdparty.libuv.git
         GIT_TAG ${LIBUV_VERSION}
     )
     FetchContent_MakeAvailable(libuv)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -40,13 +40,13 @@ include (FetchContent)
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
   FetchContent_Declare (
     googletest
-    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    URL https://github.com/intel-innersource/thirdparty.googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
     DOWNLOAD_EXTRACT_TIMESTAMP ON
   )
 else()
   FetchContent_Declare (
     googletest
-    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    URL https://github.com/intel-innersource/thirdparty.googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
   )
 endif()
 

--- a/tests/unit/unit_common.cmake
+++ b/tests/unit/unit_common.cmake
@@ -99,7 +99,7 @@ set (gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 include (FetchContent)
 FetchContent_Declare (
     googletest
-    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    URL https://github.com/intel-innersource/thirdparty.googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
 )
 FetchContent_MakeAvailable (googletest)
 

--- a/tests/unit/wasm-c-api/CMakeLists.txt
+++ b/tests/unit/wasm-c-api/CMakeLists.txt
@@ -55,7 +55,7 @@ set (gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 include (FetchContent)
 FetchContent_Declare (
     googletest
-    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    URL https://github.com/intel-innersource/thirdparty.googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
 )
 FetchContent_MakeAvailable (googletest)
 endif()


### PR DESCRIPTION
## Summary
- update the unit test CMake scripts to download googletest from the Intel third-party fork
- point the libc-uvwasi build to the Intel third-party libuv repository when fetching sources